### PR TITLE
Fix ganga launch command

### DIFF
--- a/ganga-first-steps/ganga-first-steps.md
+++ b/ganga-first-steps/ganga-first-steps.md
@@ -43,7 +43,7 @@ _you don't even have to install it_.
 On your terminal with CVMFS access, Ganga can be started
 by simply typing
 ```bash
-$ source /cvmfs/ganga.cern.ch/runGanga.sh
+$ /cvmfs/ganga.cern.ch/runGanga.sh
 ```
 After various welcome messages have been presented,
 you should see the Ganga command prompt:


### PR DESCRIPTION
I'm asking to remove the source from the command to run ganga as this causes things to break for users in usual and odd ways.

This was reported by an LSST user.