### PR TITLE
Updates wrt DIRAC

### DIFF
--- a/dirac-create-ui/dirac-create-ui.md
+++ b/dirac-create-ui/dirac-create-ui.md
@@ -22,7 +22,7 @@ We'll create a GridPP DIRAC UI now.
 
 Before proceeding, check you that you have:
 
-* Command line access to an SL6 machine;
+* Command line access to an SL7-type machine;
 * Your converted Grid certificate files in the `~/.globus` directory;
 * Successfully registered with a GridPP DIRAC-supported VO.
 
@@ -36,40 +36,9 @@ before submitting a
 [support request](https://github.com/gridpp/user-guides/issues).
 
 ##Installing the GridPP DIRAC UI
-To create a GridPP DIRAC on your SL6 machine,
-start a fresh terminal session
-(we'll assume you're using a GridPP CernVM)
-and enter the following commands:
-```bash
-$ cd ~
-$ mkdir dirac_ui
-$ cd dirac_ui
-$ wget -np -O dirac-install http://lhcbproject.web.cern.ch/lhcbproject/dist/Dirac_project/dirac-install
-.
-. [Much output.]
-.
-$ chmod u+x dirac-install
-$ ./dirac-install -r v6r15p6 -i 27 -g 2015-09-03
-.
-. [Many messages.]
-.
-2015-10-05 12:08:14 UTC dirac-install [NOTICE] DIRAC properly installed
-$ . bashrc 
-$ dirac-proxy-init -x # needs user cert password
-Generating proxy... 
-Enter Certificate password:
-Proxy generated: 
-subject      : /C=UK/O=eScience/OU=QueenMaryLondon/L=Computing/CN=ada lovelace/CN=proxy
-issuer       : /C=UK/O=eScience/OU=QueenMaryLondon/L=Computing/CN=ada lovelace
-identity     : /C=UK/O=eScience/OU=QueenMaryLondon/L=Computing/CN=ada lovelace
-timeleft     : 23:59:59
-path         : /tmp/x509up_u501
-$ dirac-configure -F -S GridPP -C dips://dirac01.grid.hep.ph.ic.ac.uk:9135/Configuration/Server -I
-.
-.[So grid]
-.
-```
 
+The maintainers of the GridPP DIRAC instance recommend that you install your DIRAC UI locally (you do not need root access) by following the procedure descibed [here](https://www.gridpp.ac.uk/wiki/Quick_Guide_to_Dirac). All updates in DIRAC versions will also be published on this page (and possibly on this page only).
+<br>
 That should configure your new GridPP DIRAC UI ready for use.
 Close and re-open the terminal (or log out and in again)
 before proceeding.

--- a/example-workflow-grid/example-workflow-grid.md
+++ b/example-workflow-grid/example-workflow-grid.md
@@ -3,7 +3,12 @@ Now that you have your Grid certificate, and it is installed
 in your browser and in your `~/.globus` directory,
 you're ready to try submitting a job to the Grid with DIRAC.
 
-## Activate DIRAC!
+# Submitting your jobs to the GridPP DIRAC instance
+The maintainers of the GridPP DIRAC instance recommend that you install your DIRAC UI locally (you do not need root access) by following the procedure descibed [here](https://www.gridpp.ac.uk/wiki/Quick_Guide_to_Dirac). All updates in DIRAC versions will also be published on this page. If you are an extablished Ganga user, you can find instructions on how to use Ganga for this [below](#activatedirac). <br><br>
+We recommend that you follow the instructions provided on the [GridPP Wiki](https://www.gridpp.ac.uk/wiki/Quick_Guide_to_Dirac) to check your basic Grid setup is working and to familiarize yourself with its functionalities.
+
+
+## <a name="#activatedirac"></a>Ganga: Activate DIRAC!
 Thanks to CVMFS and the
 [Ganga team](https://github.com/ganga-devs/),
 activating the GridPP DIRAC functionality is easy:
@@ -26,7 +31,7 @@ your own DIRAC UI. Which makes life <em>a lot</em> easier...
 </tr>
 </table>
 
-## Generate a Grid proxy
+## Ganga and generic Grid usage: Generate a Grid proxy
 With DIRAC activated via CVMFS,
 you should now be able generate a DIRAC-specific proxy
 to be used as a member of a DIRAC-enabled VO.
@@ -113,7 +118,7 @@ You can find a list of Storage Elements names by using the
 You can then re-start Ganga; it will now be ready to connect
 to the DIRAC backend.
 
-# Run your job on the Grid
+# Ganga: Run your job on the Grid
 Now you're ready to run your job on the Grid.
 First, make a copy of the `local_job.py` script:
 ```bash

--- a/getting-on-the-grid/joining-a-vo.md
+++ b/getting-on-the-grid/joining-a-vo.md
@@ -17,12 +17,7 @@ instructions you need to join.
 
 If you're interesting in using the grid but are not (yet) working as part of
 a user community already represented by a VO, worry not.
-GridPP have created a catch-all VO - [`gridpp`](https://voms.gridpp.ac.uk:8443/voms/gridpp/) - and four
-Regional Virtual Organisations (RVOs) corresponding to the
-four Tier 2s that can be joined to test out what the grid has to offer.
-Once you have used these "incubator" VOs to see if the Grid meets
-your needs, you can then think about creating your own
-Virtual Organisation to represent your user community.
+GridPP have created a catch-all VO - [`gridpp`](https://voms.gridpp.ac.uk:8443/voms/gridpp/).
 
 <table>
 <tr>
@@ -70,17 +65,6 @@ To join the
 using a browser that has your grid certificate installed
 and follow the instructions.
 
-###Joining a Regional VO
-Likewise, you can join one of the four regional VOs by clicking
-on the links in the table below 
-and following the instructions.
-
-| Regional VO | Resource Centres |
-| --- | --- |
-| <a href="https://voms.gridpp.ac.uk:8443/voms/vo.londongrid.ac.uk/register/start.action" target="_blank">`vo.londongrid.ac.uk`</a> | Brunel, UCL, Imperial College, Queen Mary, Royal Holloway |
-| <a href="https://voms.gridpp.ac.uk:8443/voms/vo.northgrid.ac.uk/register/start.action" target="_blank">`vo.northgrid.ac.uk`</a> | Lancaster, Liverpool, Manchester, Sheffield, Daresbury Laboratory |
-| <a href="https://voms.gridpp.ac.uk:8443/voms/vo.scotgrid.ac.uk" target="_blank">`vo.scotgrid.ac.uk`</a> | Glasgow, Edinburgh, Durham |
-| <a href="https://voms.gridpp.ac.uk:8443/voms/vo.southgrid.ac.uk" target="_blank">`vo.southgrid.ac.uk`</a> | Birmingham, Bristol, Cambridge, Oxford, Warwick, Rutherford Appleton Laboratory, EFDA-JET, Sussex |
 
 <table>
 <tr>


### PR DESCRIPTION
This guide is now so old that some information contained in it causes more harm than good.
I tried to update all bits relevant to the GridPP DIRAC instance:
removed obsolete instructions relating to DIRAC, 
added link to maintained DIRAC UI page, 
removed references to non-existent londongrid, 
re-wrote examp.le workflow page to make it stop looking like you needed Ganga to access the GridPP DIRAC instance